### PR TITLE
Fix names

### DIFF
--- a/eyeliner.el
+++ b/eyeliner.el
@@ -30,8 +30,8 @@
 
 (defun eyeliner/transform (form)
   "Transform FORM into a form suitable for a let binding"
-  (if (ignore-errors (fboundp expr)) `(it (apply (quote ,expr) (list it)))
-    `(it ,expr)))
+  (if (ignore-errors (fboundp form)) `(it (apply (quote ,form) (list it)))
+    `(it ,form)))
 
 (defmacro eyeliner/pipeline (value &rest exprs)
   "Bind VALUE to 'it and evaluate each of EXPRS. The result of
@@ -47,7 +47,7 @@
 
 (defun eyeliner/adjust-color (color &optional darkness desaturation)
   "Return COLOR modified by DARKNESS and DESATURATION"
-  (pipeline color
+  (eyeliner/pipeline color
     (color-darken-name it (or darkness eyeliner/default-darkness))
     (color-desaturate-name it (or desaturation eyeliner/default-desaturation))))
 

--- a/eyeliner.org
+++ b/eyeliner.org
@@ -43,8 +43,8 @@
 #+begin_src emacs-lisp
   (defun eyeliner/transform (form)
     "Transform FORM into a form suitable for a let binding"
-    (if (ignore-errors (fboundp expr)) `(it (apply (quote ,expr) (list it)))
-      `(it ,expr)))
+    (if (ignore-errors (fboundp form)) `(it (apply (quote ,form) (list it)))
+      `(it ,form)))
 #+end_src
 
 *** pipeline
@@ -69,7 +69,7 @@
 #+begin_src emacs-lisp
   (defun eyeliner/adjust-color (color &optional darkness desaturation)
     "Return COLOR modified by DARKNESS and DESATURATION"
-    (pipeline color
+    (eyeliner/pipeline color
       (color-darken-name it (or darkness eyeliner/default-darkness))
       (color-desaturate-name it (or desaturation eyeliner/default-desaturation))))
 #+end_src


### PR DESCRIPTION
This PR addresses errors that occur when loading `eyeliner`, e.g. #1.

In particular, `pipeline` should be referenced as `eyeliner/pipeline` and `expr` in `eyeliner/transform` _seems_ like it should be `form`.